### PR TITLE
Updated UUIDProperty to serialize as None if value is None

### DIFF
--- a/odata/property.py
+++ b/odata/property.py
@@ -311,6 +311,8 @@ class UUIDProperty(StringProperty):
     filters do not use quotes for UUID
     """
     def serialize(self, value):
+        if value is None:
+            return None
         return str(value)
 
     def deserialize(self, value):


### PR DESCRIPTION
If the UUIDProperty was previously set to None the value would have been serialized as 'None' instead of None (string instead of NoneType). This leads to a 400 Bad Request if the controller is expecting a UUID.